### PR TITLE
feat: :rocket: add GitHub Actions support to publish extension automatically

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,21 @@
+name: Deploy VSCode extension
+
+on:
+  create:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn
+      - run: yarn deploy -p ${{ secrets.VSCE_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -275,7 +275,8 @@
     "lint": "eslint src --ext ts",
     "watch": "tsc -watch -p ./",
     "pretest": "yarn run compile && yarn run lint",
-    "test": "node ./out/test/runTest.js"
+    "test": "node ./out/test/runTest.js",
+    "deploy": "vsce publish --yarn"
   },
   "devDependencies": {
     "@types/glob": "^7.1.1",
@@ -288,6 +289,7 @@
     "glob": "^7.1.6",
     "mocha": "^7.1.2",
     "typescript": "^3.8.3",
+    "vsce": "^1.78.0",
     "vscode-test": "^1.3.0"
   },
   "dependencies": {


### PR DESCRIPTION
增加一个自动发布到 VSCode 插件市场的 GitHub Actions CI：当有新 `tag` 产生时，会自动触发发布脚本进行发布，以提高发布效率。

需要在项目 _Settings -> Secrets_  新增一个名为 **VSCE_TOKEN** 的密对，这个 token 可以在 [Publishing Extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token) 进行申请。