### PR TITLE
修复某些暗色主题下基金刷新按钮显示灰色的bug，统一基金和股票的刷新按钮

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,10 @@
       {
         "command": "leek-fund.refreshFund",
         "title": "刷新数据",
-        "icon": "$(refresh)"
+        "icon": {
+          "light": "resources/light/refresh.svg",
+          "dark": "resources/dark/refresh.svg"
+        }
       },
       {
         "command": "leek-fund.sortStock",


### PR DESCRIPTION
我使用的暗色主题下，原来的基金刷新按钮显示成灰色了，误以为不可点击，现统一成股票栏目的刷新按钮
![image](https://user-images.githubusercontent.com/8085344/96553211-68354900-12e7-11eb-98fa-aa49f4485be2.png)
