### PR TITLE
fix: 基金涨跌排序切换失效的问题

### DIFF
--- a/src/explorer/fundProvider.ts
+++ b/src/explorer/fundProvider.ts
@@ -36,6 +36,12 @@ export class FundProvider implements TreeDataProvider<LeekTreeItem> {
 
   changeOrder(): void {
     let order = this.order as number;
+
+    /* fix: 如果基金排序先前是按照持仓金额升序/降序, 按涨跌排序失效的问题 */
+    if (Math.abs(order) > 1) {
+      this.order = SortType.NORMAL;
+    }
+
     order += 1;
     if (order > 1) {
       this.order = SortType.DESC;


### PR DESCRIPTION
**基金模块**

点击持仓金额升序/降序(`leek-fund.sortAmountFund`)

此时 `leek-fund.fundSort` 为 `2/-2`

点击升序/降序/不排序(`leek-fund.sortFund`)

按此前逻辑, 回不去按涨跌排序的逻辑